### PR TITLE
feat: add function to remove duplicate case-sensitive words from text

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ const count = stringzy.analyze.wordCount('Hello world'); // 2
 - [capitalizeWords](#capitalizewords) - Capitalizes the first letter of each word
 - [removeSpecialChars](#removespecialchars) - Removes special characters from a string
 - [removeWords](#removewords) - Removes specified words from a string
+- [removeDuplicates](#removeduplicates) - Removes specified words from a string
 - [initials](#initials) - Extracts initials from a text string
 - [camelCase](#camelcase) - Converts the given string to Camel Case
 - [pascaslCase](#pascalcase) - Converts the given string to Pascal Case
@@ -206,6 +207,27 @@ removeWords('JavaScript is awesome and JavaScript rocks', ['JavaScript']);
 |-----------|------|---------|-------------|
 | text | string | required | The input string to process |
 | wordsToRemove | string[] | required | Array of words to remove from the string |
+
+#### <a id="removeduplicates"></a>`removeDuplicates(text)`
+
+Removes duplicate case-sensitive words from a given text. 
+
+```javascript
+import { removeDuplicates } from 'stringzy';
+
+removeDuplicates('Hello world this is a is a test');
+// Returns: 'Hello world this is a test'
+
+removeDuplicates('Remove me me me me or Me');
+// Returns: 'Remove me or Me'' 
+
+removeDuplicates('JavaScript is not bad and not awesome');
+// Returns: 'JavaScript is not bad and awesome'
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| text | string | required | The input string to process |
 
 #### <a id="initials"></a>`initials(text, limit)`
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ export const {
   constantCase,
   removeWords,
   initials,
+  removeDuplicates
 } = transformations;
 
 export const {

--- a/transformations.js
+++ b/transformations.js
@@ -174,3 +174,17 @@ export function initials(text, limit) {
 
   return initialsArray.join("");
 }
+
+export function removeDuplicates(text) {
+  if (typeof text !== "string") {
+    throw new Error("Input must be a string");
+  }
+
+  const wordSet = new Set();
+
+  text.split(" ").forEach((word) => {
+    wordSet.add(word);
+  });
+
+  return Array.from(wordSet).join(" ");
+}


### PR DESCRIPTION
### Add removeDuplicates Function
This pull request introduces a new utility function called removeDuplicates to the stringzy package.

The removeDuplicates(text) function removes duplicate words from a given string while preserving the original order and respecting case sensitivity.

Function behavior:

Words are considered duplicates only if they match exactly (case-sensitive).

The order of first occurrence is preserved.

Non-string inputs will throw an error.

Examples:

removeDuplicates('Hello world this is a is a test')
→ 'Hello world this is a test'

removeDuplicates('Remove me me me me or Me')
→ 'Remove me or Me'

removeDuplicates('JavaScript is not bad and not awesome')
→ 'JavaScript is not bad and awesome'

Parameter:

text (string, required): The input string to process.

If text is not a string, the function throws:
Error: Input must be a string