### PR TITLE
removed toUpperCase from readme code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pnpm add stringzy
 import stringzy from 'stringzy';
 
 // Or import specific functions
-import { toUpperCase, isEmail, wordCount, formatPhone } from 'stringzy';
+import { isEmail, wordCount, formatPhone } from 'stringzy';
 
 // Or import by namespace
 import { transform, validate, analyze, format } from 'stringzy';


### PR DESCRIPTION
Updated readme, removed toUpperCase from import statement in the code as it is not a function in the package. It is just a normal java script function. 
#33 