### PR TITLE
feat: add deburr utility to strip diacritics from strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,26 @@ maskSegment('token');
 |maskEnd	|number|	`text.length`|	The end index (exclusive) of the segment to mask|
 |maskChar	|string	|`'*'` |	The character to use for masking (must be one character)|
 
+#### <a id="deburr"></a>deburr(text)
+Removes accents and diacritics from letters in a string (e.g. déjà vu → deja vu).
+
+```javascript
+import { deburr } from 'stringzy';
+
+deburr('déjà vu');
+// Returns: 'deja vu'
+
+deburr('Élève São Paulo');
+// Returns: 'Eleve Sao Paulo'
+
+deburr('über cool');
+// Returns: 'uber cool'
+
+```
+| Parameter | Type   | Default  Description                               |
+| --------- | ------ | -------- | ----------------------------------------- |
+| text      | string | required | The input string to strip diacritics from |
+
 ---
 
 ### ✅ Validations

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ const count = stringzy.analyze.wordCount('Hello world'); // 2
 - [constantCase](#constantcase) - Converts the given string to Constant Case
 - [escapeHTML](#escapehtml) - Escapes HTML special characters to prevent XSS attacks
 - [maskSegment](#masksegment) - Masks a segment of a string by replacing characters between two indices with a specified character
+- [deburr](#deburr) – Removes accents and diacritical marks from a string
 
 
 ###  Validations

--- a/src/tests/transformations/deburr.test.ts
+++ b/src/tests/transformations/deburr.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { deburr } from '../../transformations/deburr';
+
+describe('deburr', () => {
+  it('removes accents and diacritics', () => {
+    assert.strictEqual(deburr('déjà vu'), 'deja vu');
+    assert.strictEqual(deburr('Élève'), 'Eleve');
+    assert.strictEqual(deburr('São Paulo'), 'Sao Paulo');
+    assert.strictEqual(deburr('über cool'), 'uber cool');
+  });
+
+  it('returns the original string if no accents present', () => {
+    assert.strictEqual(deburr('hello world'), 'hello world');
+  });
+
+  it('returns empty string if input is empty', () => {
+    assert.strictEqual(deburr(''), '');
+  });
+
+  it('throws an error if input is not a string', () => {
+    assert.throws(() => deburr(123 as any), /Input must be a string/);
+    assert.throws(() => deburr(null as any), /Input must be a string/);
+    assert.throws(() => deburr(undefined as any), /Input must be a string/);
+  });
+});

--- a/src/transformations/deburr.ts
+++ b/src/transformations/deburr.ts
@@ -1,0 +1,14 @@
+/**
+ * Removes accents and diacritics from letters in a string.
+ * @param str - Input string
+ * @returns A deburred string without accented characters.
+ * @throws Error if input is not a string
+ */
+export function deburr(str: string): string {
+  if (typeof str !== 'string') {
+    throw new Error('Input must be a string');
+  }
+
+  // Normalize and strip combining marks (diacritics)
+  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}

--- a/src/transformations/index.ts
+++ b/src/transformations/index.ts
@@ -30,6 +30,7 @@ import { toSlug } from './toSlug';
 import { truncateText } from './truncateText';
 import { escapeHtml } from './escapeHTML';
 import { maskSegment } from './maskSegment';
+import { deburr } from './deburr';
 
 export const transformations = {
     camelCase,
@@ -46,5 +47,6 @@ export const transformations = {
     toSlug,
     truncateText,
     escapeHtml,
-    maskSegment
+    maskSegment,
+    deburr
 };


### PR DESCRIPTION
This PR introduces a new utility function **deburr()** that removes accents and diacritical marks from characters in a string _(e.g., "déjà vu" → "deja vu")._

What's Included
New function: deburr(text: string)

Full test coverage

Input validation with error handling

README section with usage examples and signature

Why
Normalizing strings is important for search, comparison, and URL generation. This adds useful string processing functionality to the library.

Let me know if any changes are needed!