### PR TITLE
docs: fix table formatting in deburr section

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ deburr('über cool');
 // Returns: 'uber cool'
 
 ```
-| Parameter | Type   | Default  Description                               |
+| Parameter | Type   | Default |  Description                               |
 | --------- | ------ | -------- | ----------------------------------------- |
 | text      | string | required | The input string to strip diacritics from |
 


### PR DESCRIPTION
Just a small docs fix for the table in the deburr section
The | was missing after Default in the table causing the table not to be displayed properly