### PR TITLE
feat: add String.prototype extensions (camelCase, capitalizeWords)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,17 @@
+import { camelCase } from './transformations/camelCase';
+import { capitalizeWords } from './transformations/capitalizeWords';
+
+declare global {
+  interface String {
+    camelCase(): string;   // 👈 match the existing function name
+    capitalizeWords(): string;
+  }
+}
+
+String.prototype.camelCase = function () {
+  return camelCase(this.toString());
+};
+String.prototype.capitalizeWords = function () {
+  return capitalizeWords(this.toString());
+};
+export {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ import { formatting } from './formatting';
 import { transformations } from './transformations';
 import { validations } from './validations';
 
+//importing the extension to ensure String prototype is extended
+import './extension';
+
 export default {
   analyzing,
   formatting,

--- a/src/tests/extension.test.ts
+++ b/src/tests/extension.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import "../extension";
+
+test("should convert to camelCase", () => {
+  const result = "hello world".camelCase();
+  assert.equal(result, "helloWorld");
+});
+
+test("should capitalize words", () => {
+  const result = "hello world".capitalizeWords(); 
+  assert.equal(result, "Hello World");
+});
+
+test("should chain methods (camelCase + capitalizeWords)", () => {
+  const result = "string example".camelCase().capitalizeWords(); 
+  assert.equal(result, "StringExample");
+});


### PR DESCRIPTION
Added String.prototype extensions:
- camelCase( ): converts strings to camelCase
- capitalizeWords( ): capitalizes each word

Includes tests for both functions and chaining.

Note: The original feature request mentioned camelWord(), but since the library already provides a camelCase() transformation, I implemented camelCase() for consistency. Please let me know if you’d prefer a different method name.