### PR TITLE
feat: add String.prototype chaining support for camelCase and capital…

### DIFF
--- a/src/Prototype.ts
+++ b/src/Prototype.ts
@@ -1,0 +1,42 @@
+
+import { camelCase, pascalCase, capitalizeWords } from './transformations';  
+
+declare global {
+  interface String {
+    camelCase(): string;
+    pascalCase(): string;
+    capitalizeWords(): string;
+  }
+}
+
+if (!String.prototype.camelCase) {
+  Object.defineProperty(String.prototype, 'camelCase', {
+    value: function () {
+      return camelCase(this.toString());
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+if (!String.prototype.pascalCase) {
+  Object.defineProperty(String.prototype, 'pascalCase', {
+    value: function () {
+      return pascalCase(this.toString());
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+if (!String.prototype.capitalizeWords) {
+  Object.defineProperty(String.prototype, 'capitalizeWords', {
+    value: function () {
+      return capitalizeWords(this.toString());
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+// (Add more methods similarly)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export * from './analyzing';
 export * from './formatting';
 export * from './transformations';
 export * from './validations';
+export * from './Prototype';
+
 
 import { analyzing } from './analyzing';
 import { formatting } from './formatting';

--- a/src/tests/prototype.test.ts
+++ b/src/tests/prototype.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import '../Prototype';
+import { camelCase, capitalizeWords } from '../transformations';
+
+test('String.prototype chaining: camelCase -> capitalizeWords', () => {
+  expect('hello world'.camelCase().capitalizeWords()).toBe(
+    capitalizeWords(camelCase('hello world'))
+  );
+});
+function expect(actual: string) {
+    return {
+        toBe(expected: string) {
+            if (actual !== expected) {
+                throw new Error(`Expected '${actual}' to be '${expected}'`);
+            }
+        }
+    };
+}
+


### PR DESCRIPTION
### Summary
This PR adds support for extending `String.prototype` to enable chaining of string transformation functions, making the syntax cleaner and more intuitive.

### Example
```js
// Before
capitalizeWords(camelCase("hello world"))

// After
"hello world".camelCase().capitalizeWords()
